### PR TITLE
fix: fix options has multi field

### DIFF
--- a/src/source_entry.rs
+++ b/src/source_entry.rs
@@ -68,17 +68,20 @@ impl FromStr for SourceEntry {
                     let next =
                         fields.next().ok_or(SourceError::MissingField { field: "option" })?;
                     if let Some(pos) = next.find(']') {
+                        field.push_str(" ");
                         field.push_str(&next[..pos]);
                         if pos != next.len() - 1 {
                             leftover = Some(next[pos + 1..].into());
                         }
                         break;
                     } else {
+                        field.push_str(" ");
                         field.push_str(next);
                     }
                 }
 
                 options = Some(field);
+                options = options.map(|x| x.trim().to_string());
             }
 
             url = match leftover {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -154,4 +154,25 @@ fn options() {
             })
         )
     }
+
+    let options = [
+        "deb [arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b] https://deb.termius.com squeeze main",
+        "deb [ arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b] https://deb.termius.com squeeze main",
+        "deb [ arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b ] https://deb.termius.com squeeze main",
+        "deb [arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b ] https://deb.termius.com squeeze main"
+    ];
+
+    for source in &options {
+        assert_eq!(
+            SourceLine::from_str(source).unwrap(),
+            SourceLine::Entry(SourceEntry {
+                enabled: true,
+                source: false,
+                url: "https://deb.termius.com".into(),
+                suite: "squeeze".into(),
+                options: Some("arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b".into()),
+                components: vec!["main".into()]
+            })
+        )
+    }
 }


### PR DESCRIPTION
`deb [arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b] https://deb.termius.com squeeze main`

will get wrong result:

```
&options = "arch=amd64signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpga=b
```

This PR will fix this issue:

```
arch=amd64 signed-by=/usr/share/keyrings/termius-2023.gpg,/usr/share/keyrings/termius-2026.gpg a=b
```